### PR TITLE
fix: resolve #2 — 🟡 [AI-QA] Crontab environment variable detection fails for values containing spaces

### DIFF
--- a/MacTimer/Services/SystemTaskDiscoveryService.swift
+++ b/MacTimer/Services/SystemTaskDiscoveryService.swift
@@ -222,8 +222,9 @@ final class SystemTaskDiscoveryService: ObservableObject {
         // 跳过空行和注释
         guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return nil }
 
-        // 处理环境变量设置行（如 SHELL=/bin/bash, PATH=...）
-        if trimmed.contains("=") && !trimmed.contains(" ") {
+        // 处理环境变量设置行（如 SHELL=/bin/bash, PATH=..., CRON_TZ="America/New York"）
+        // Use regex: line starts with a valid identifier followed by '='
+        if trimmed.range(of: #"^[A-Za-z_][A-Za-z0-9_]*="#, options: .regularExpression) != nil {
             return nil
         }
 


### PR DESCRIPTION
## Summary
Auto-fix for #2

## Changes
- fix: resolve issue #2 — use regex for crontab env var detection

## Issue Reference
Closes #2

---
🤖 *此 PR 由 AI Fix Agent 自动创建*