### PR TITLE
fix: resolve #3 — 🟡 [AI-QA] Crontab task IDs are unstable across Swift versions due to hashValue usage

### DIFF
--- a/MacTimer/Services/SystemTaskDiscoveryService.swift
+++ b/MacTimer/Services/SystemTaskDiscoveryService.swift
@@ -248,8 +248,11 @@ final class SystemTaskDiscoveryService: ObservableObject {
         // 生成可读名称：取命令的最后一个路径组件或前 40 字符
         let name = extractCronTaskName(command)
 
-        // id 用行内容的 hash，确保稳定
-        let id = "crontab:\(trimmed.hashValue)"
+        // id 用行内容的确定性 hash（DJB2），确保跨进程启动稳定
+        let stableHash = trimmed.utf8.reduce(into: UInt64(5381)) { hash, byte in
+            hash = ((hash &<< 5) &+ hash) &+ UInt64(byte)
+        }
+        let id = "crontab:\(stableHash)"
 
         return SystemTask(
             id: id,


### PR DESCRIPTION
## Summary
Auto-fix for #3

## Changes
- fix: resolve issue #3 — use deterministic DJB2 hash for crontab task IDs

## Issue Reference
Closes #3

---
🤖 *此 PR 由 AI Fix Agent 自动创建*