### PR TITLE
fix: resolve #9 — 🟡 [AI-QA] Pipe readabilityHandler and Process lifecycle race in shell execution

### DIFF
--- a/MacTimer/Services/TaskExecutor.swift
+++ b/MacTimer/Services/TaskExecutor.swift
@@ -75,7 +75,20 @@ final class TaskExecutor {
 
             DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds) {
                 if process.isRunning {
-                    process.terminate()
+                    // Clear the readabilityHandler immediately so it stops firing
+                    // even if the process doesn't exit cleanly after SIGTERM.
+                    pipe.fileHandleForReading.readabilityHandler = nil
+
+                    process.terminate() // SIGTERM
+
+                    // Escalate: if process survives SIGTERM, send SIGKILL after a grace period.
+                    let pid = process.processIdentifier
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                        if process.isRunning {
+                            kill(pid, SIGKILL)
+                        }
+                    }
+
                     // Protect timedOut write under outputLock to avoid data race
                     // with the read that occurs after waitUntilExit() returns.
                     outputLock.lock(); timedOut = true; outputLock.unlock()
@@ -85,6 +98,10 @@ final class TaskExecutor {
 
             DispatchQueue.global().async {
                 process.waitUntilExit()
+                // Ensure handler is cleared and FD is closed once the process exits,
+                // regardless of whether it was a normal exit or a timeout kill.
+                pipe.fileHandleForReading.readabilityHandler = nil
+                try? pipe.fileHandleForReading.close()
                 resume(with: process.terminationStatus == 0)
             }
         }


### PR DESCRIPTION
## Summary
Auto-fix for #9

## Changes
- fix: resolve issue #9 — clear readabilityHandler and escalate to SIGKILL on shell timeout

## Issue Reference
Closes #9

---
🤖 *此 PR 由 AI Fix Agent 自动创建*