### PR TITLE
fix: resolve #10 — 🟡 [AI-QA] TaskItem deletion does not clean up orphaned ExecutionLogItem records

### DIFF
--- a/MacTimer/UI/MainWindow/TaskListView.swift
+++ b/MacTimer/UI/MainWindow/TaskListView.swift
@@ -262,6 +262,16 @@ struct TaskListView: View {
     private func deleteTask(_ task: TaskItem) {
         task.isEnabled = false
         scheduler.reschedule(task: task)
+
+        // Clean up orphaned ExecutionLogItem records linked by taskID
+        let logRequest = ExecutionLogItem.fetchRequest()
+        logRequest.predicate = NSPredicate(format: "taskID == %@", task.id as CVarArg)
+        if let logs = try? context.fetch(logRequest) {
+            for log in logs {
+                context.delete(log)
+            }
+        }
+
         context.delete(task)
         try? context.save()
     }


### PR DESCRIPTION
## Summary
Auto-fix for #10

## Changes
- fix: resolve issue #10 — delete orphaned ExecutionLogItem records when removing a task

## Issue Reference
Closes #10

---
🤖 *此 PR 由 AI Fix Agent 自动创建*