### PR TITLE
fix: resolve #25 — 🟠 [AI-QA] ScheduleCalculator.nextRunAt uses strict >= comparison causing potential double-execution

### DIFF
--- a/MacTimer/Services/ScheduleCalculator.swift
+++ b/MacTimer/Services/ScheduleCalculator.swift
@@ -61,7 +61,7 @@ struct ScheduleCalculator {
                         continue
                     }
                 }
-                if fireDate >= date {
+                if fireDate > date {
                     return fireDate
                 }
             }


### PR DESCRIPTION
## Summary
Auto-fix for #25

## Changes
- fix: resolve issue #25 — use strict > comparison in nextRunAt to prevent double-execution

## Issue Reference
Closes #25

---
🤖 *此 PR 由 AI Fix Agent 自动创建*