### PR TITLE
fix: resolve #27 — 🟡 [AI-QA] IntervalConfig.seconds has no minimum enforcement in the model

### DIFF
--- a/MacTimer/Models/Schedule.swift
+++ b/MacTimer/Models/Schedule.swift
@@ -37,6 +37,18 @@ struct FixedTimeConfig: Codable {
 struct IntervalConfig: Codable {
     var seconds: Int      // minimum 60
     var startImmediately: Bool
+
+    init(seconds: Int, startImmediately: Bool) {
+        self.seconds = max(60, seconds)
+        self.startImmediately = startImmediately
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawSeconds = try container.decode(Int.self, forKey: .seconds)
+        self.seconds = max(60, rawSeconds)
+        self.startImmediately = try container.decode(Bool.self, forKey: .startImmediately)
+    }
 }
 
 struct ScheduleConfig: Codable {

--- a/MacTimer/Services/ScheduleCalculator.swift
+++ b/MacTimer/Services/ScheduleCalculator.swift
@@ -13,7 +13,7 @@ struct ScheduleCalculator {
     ) -> Date? {
         switch schedule.type {
         case .interval:
-            guard let cfg = schedule.interval else { return nil }
+            guard let cfg = schedule.interval, cfg.seconds >= 60 else { return nil }
             if isFirstRun && cfg.startImmediately {
                 return date
             }


### PR DESCRIPTION
## Summary
Auto-fix for #27

## Changes
- fix: resolve issue #27 — enforce minimum 60s for IntervalConfig.seconds

## Issue Reference
Closes #27

---
🤖 *此 PR 由 AI Fix Agent 自动创建*