### PR TITLE
fix: resolve #31 — 🟠 [AI-QA] CoreData context accessed from wrong thread in handleDidWake

### DIFF
--- a/MacTimer/Services/SchedulerService.swift
+++ b/MacTimer/Services/SchedulerService.swift
@@ -196,14 +196,17 @@ final class SchedulerService: ObservableObject {
 
         let wsc = NSWorkspace.shared.notificationCenter
         wsc.addObserver(
-            self,
-            selector: #selector(handleDidWake(_:)),
-            name: NSWorkspace.didWakeNotification,
-            object: nil
-        )
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.handleDidWake()
+            }
+        }
     }
 
-    @objc private func handleDidWake(_ notification: Notification) {
+    private func handleDidWake() {
         // After waking from sleep, check all enabled tasks for missed executions.
         let request = TaskItem.fetchRequest()
         request.predicate = NSPredicate(format: "isEnabled == YES")


### PR DESCRIPTION
## Summary
Auto-fix for #31

## Changes
- fix: resolve issue #31 — ensure handleDidWake runs on main thread for CoreData safety

## Issue Reference
Closes #31

---
🤖 *此 PR 由 AI Fix Agent 自动创建*