### PR TITLE
fix: resolve #34 — 🟡 [AI-QA] todayPendingCount uses hardcoded 86400 seconds which is wrong during DST transitions

### DIFF
--- a/MacTimer/UI/MenuBar/MenuBarView.swift
+++ b/MacTimer/UI/MenuBar/MenuBarView.swift
@@ -114,7 +114,10 @@ struct MenuBarView: View {
 
     private var todayPendingCount: Int {
         let cal = Calendar.current
-        let endOfDay = cal.startOfDay(for: Date()).addingTimeInterval(86400)
+        let startOfToday = cal.startOfDay(for: Date())
+        guard let endOfDay = cal.date(byAdding: .day, value: 1, to: startOfToday) else {
+            return 0
+        }
         return enabledTasks.filter { task in
             guard let next = task.nextRunAt else { return false }
             return next <= endOfDay


### PR DESCRIPTION
## Summary
Auto-fix for #34

## Changes
- fix: resolve issue #34 — use Calendar.date(byAdding:) instead of hardcoded 86400s for DST-safe end-of-day calculation

## Issue Reference
Closes #34

---
🤖 *此 PR 由 AI Fix Agent 自动创建*