### PR TITLE
fix: resolve #36 — 🟡 [AI-QA] Schedule type change in editor doesn't initialize corresponding config

### DIFF
--- a/MacTimer/UI/Editor/ScheduleEditorSection.swift
+++ b/MacTimer/UI/Editor/ScheduleEditorSection.swift
@@ -15,6 +15,14 @@ struct ScheduleEditorSection: View {
             }
             .pickerStyle(.segmented)
             .labelsHidden()
+            .onChange(of: schedule.type) { newType in
+                if newType == .fixedTime && schedule.fixedTime == nil {
+                    schedule.fixedTime = FixedTimeConfig(weekdays: [1, 2, 3, 4, 5], hour: 9, minute: 0)
+                }
+                if newType == .interval && schedule.interval == nil {
+                    schedule.interval = IntervalConfig(seconds: 3600, startImmediately: false)
+                }
+            }
 
             if schedule.type == .fixedTime {
                 fixedTimeFields


### PR DESCRIPTION
## Summary
Auto-fix for #36

## Changes
- fix: resolve issue #36 — initialize corresponding config when schedule type changes

## Issue Reference
Closes #36

---
🤖 *此 PR 由 AI Fix Agent 自动创建*