### PR TITLE
fix: resolve #49 — 🟡 [AI-QA] SystemTaskDiscoveryService accesses self from detached task without isolation

### DIFF
--- a/MacTimer/Services/SystemTaskDiscoveryService.swift
+++ b/MacTimer/Services/SystemTaskDiscoveryService.swift
@@ -16,10 +16,12 @@ final class SystemTaskDiscoveryService: ObservableObject {
     /// 执行一次完整扫描
     func discover() {
         Task {
+            let discoverLaunchAgents = self.discoverLaunchAgents
+            let discoverCrontab = self.discoverCrontab
             let discovered = await Task.detached {
                 var result: [SystemTask] = []
-                result.append(contentsOf: self.discoverLaunchAgents())
-                result.append(contentsOf: self.discoverCrontab())
+                result.append(contentsOf: discoverLaunchAgents())
+                result.append(contentsOf: discoverCrontab())
                 return result
             }.value
             self.tasks = discovered


### PR DESCRIPTION
## Summary
Auto-fix for #49

## Changes
- fix: resolve issue #49 — avoid capturing MainActor-isolated self in Task.detached

## Issue Reference
Closes #49

---
🤖 *此 PR 由 AI Fix Agent 自动创建*