### PR TITLE
fix: resolve #60 — 🟡 [AI-QA] Race condition: timedOut flag and finished can both be false, losing error info

### DIFF
--- a/MacTimer/Services/TaskExecutor.swift
+++ b/MacTimer/Services/TaskExecutor.swift
@@ -223,13 +223,18 @@ final class TaskExecutor {
                     // Protect timedOut write under outputLock to avoid data race
                     // with the read that occurs after waitUntilExit() returns.
                     outputLock.lock(); timedOut = true; outputLock.unlock()
+
+                    // Only resume from the timeout path when we actually killed
+                    // the process. For natural exits, let waitUntilExit handle it.
+                    resume(with: false)
                 } else {
                     // Process already exited before timeout fired (e.g. quick exit
                     // with no output). Ensure handler is cleared and FD is closed
                     // to prevent resource leaks if the EOF was missed.
                     closeHandleOnce()
+                    // Do NOT resume here — let the waitUntilExit path provide the
+                    // correct exit status so error info is not lost.
                 }
-                resume(with: false)
             }
 
             DispatchQueue.global().async {


### PR DESCRIPTION
## Summary
Auto-fix for #60

## Changes
- fix: resolve issue #60 — prevent timeout closure from stealing resume when process exits naturally

## Issue Reference
Closes #60

---
🤖 *此 PR 由 AI Fix Agent 自动创建*