### PR TITLE
fix: resolve #64 — 🟡 [AI-QA] todayPendingCount includes tasks with nextRunAt before now

### DIFF
--- a/MacTimer/UI/MenuBar/MenuBarView.swift
+++ b/MacTimer/UI/MenuBar/MenuBarView.swift
@@ -120,7 +120,8 @@ struct MenuBarView: View {
         }
         return enabledTasks.filter { task in
             guard let next = task.nextRunAt else { return false }
-            return next <= endOfDay
+            let now = Date()
+            return next >= now && next <= endOfDay
         }.count
     }
 


### PR DESCRIPTION
## Summary
Auto-fix for #64

## Changes
- fix: resolve issue #64 — exclude overdue tasks from todayPendingCount

## Issue Reference
Closes #64

---
🤖 *此 PR 由 AI Fix Agent 自动创建*