### PR TITLE
fix: resolve #61 — 🟡 [AI-QA] ScheduleConfig missing once field causes crash-loop for once-type tasks

### DIFF
--- a/MacTimer/UI/Editor/ScheduleEditorSection.swift
+++ b/MacTimer/UI/Editor/ScheduleEditorSection.swift
@@ -19,6 +19,9 @@ struct ScheduleEditorSection: View {
                 if newType == .fixedTime && schedule.fixedTime == nil {
                     schedule.fixedTime = FixedTimeConfig(weekdays: [1, 2, 3, 4, 5], hour: 9, minute: 0)
                 }
+                if newType == .once && schedule.once == nil {
+                    schedule.once = OnceConfig(date: Date().addingTimeInterval(3600))
+                }
                 if newType == .interval && schedule.interval == nil {
                     schedule.interval = IntervalConfig(seconds: 3600, startImmediately: false)
                 }

--- a/MacTimer/UI/Editor/TaskEditorView.swift
+++ b/MacTimer/UI/Editor/TaskEditorView.swift
@@ -140,6 +140,11 @@ struct TaskEditorView: View {
                 return "间隔时间最小为 60 秒"
             }
         }
+        if schedule.type == .once {
+            guard schedule.once != nil else {
+                return "请选择提醒时间"
+            }
+        }
         if schedule.type == .fixedTime {
             guard let cfg = schedule.fixedTime, !cfg.weekdays.isEmpty else {
                 return "请至少选择一个重复日"


### PR DESCRIPTION
## Summary
Auto-fix for #61

## Changes
- fix: resolve issue #61 — initialize OnceConfig when switching to once type and add validation

## Issue Reference
Closes #61

---
🤖 *此 PR 由 AI Fix Agent 自动创建*