### PR TITLE
fix: resolve #62 — 🟡 [AI-QA] Missing validation for once-type schedule in editor

### DIFF
--- a/MacTimer/UI/Editor/TaskEditorView.swift
+++ b/MacTimer/UI/Editor/TaskEditorView.swift
@@ -141,8 +141,11 @@ struct TaskEditorView: View {
             }
         }
         if schedule.type == .once {
-            guard schedule.once != nil else {
+            guard let onceDate = schedule.once else {
                 return "请选择提醒时间"
+            }
+            guard onceDate > Date() else {
+                return "提醒时间必须在当前时间之后"
             }
         }
         if schedule.type == .fixedTime {


### PR DESCRIPTION
## Summary
Auto-fix for #62

## Changes
- fix: resolve issue #62 — add past-date validation for once-type schedule

## Issue Reference
Closes #62

---
🤖 *此 PR 由 AI Fix Agent 自动创建*