### PR TITLE
fix: resolve #80 — 🟡 [AI-QA] SchedulerService.deinit calls NSWorkspace on potentially wrong thread

### DIFF
--- a/MacTimer/Services/SchedulerService.swift
+++ b/MacTimer/Services/SchedulerService.swift
@@ -44,13 +44,25 @@ final class SchedulerService: ObservableObject {
 
     deinit {
         if let observer = sleepWakeObserver {
-            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            let captured = observer
+            if Thread.isMainThread {
+                NSWorkspace.shared.notificationCenter.removeObserver(captured)
+            } else {
+                DispatchQueue.main.async {
+                    NSWorkspace.shared.notificationCenter.removeObserver(captured)
+                }
+            }
         }
     }
 
     func stop() {
         activeTimers.values.forEach { $0.invalidate() }
         activeTimers.removeAll()
+        if let observer = sleepWakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            sleepWakeObserver = nil
+            observingSleepWake = false
+        }
     }
 
     func reschedule(task: TaskItem) {


### PR DESCRIPTION
## Summary
Auto-fix for #80

## Changes
- fix: resolve issue #80 — ensure NSWorkspace observer removal happens on main thread

## Issue Reference
Closes #80

---
🤖 *此 PR 由 AI Fix Agent 自动创建*