### PR TITLE
fix: resolve #86 — 🟡 [AI-QA] Once-type task returns nil when date equals current time exactly

### DIFF
--- a/MacTimer/Services/ScheduleCalculator.swift
+++ b/MacTimer/Services/ScheduleCalculator.swift
@@ -18,7 +18,7 @@ struct ScheduleCalculator {
         switch schedule.type {
         case .once:
             guard let cfg = schedule.once else { return nil }
-            return cfg.date > date ? cfg.date : nil
+            return cfg.date >= date ? cfg.date : nil
 
         case .interval:
             guard let cfg = schedule.interval, cfg.seconds >= 60 else { return nil }


### PR DESCRIPTION
## Summary
Auto-fix for #86

## Changes
- fix: resolve issue #86 — use >= for once-task date comparison

## Issue Reference
Closes #86

---
🤖 *此 PR 由 AI Fix Agent 自动创建*