### PR TITLE
fix: resolve #87 — 🟡 [AI-QA] SchedulerService deinit accesses actor-isolated property unsafely

### DIFF
--- a/MacTimer/Services/SchedulerService.swift
+++ b/MacTimer/Services/SchedulerService.swift
@@ -15,7 +15,7 @@ final class SchedulerService: ObservableObject {
 
     /// Tracks whether sleep/wake observers have been registered
     private var observingSleepWake = false
-    private var sleepWakeObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var sleepWakeObserver: NSObjectProtocol?
 
     /// Tracks task IDs currently being executed to prevent duplicate execution
     /// (e.g. race between RunLoop-fired timer and wake handler)


### PR DESCRIPTION
## Summary
Auto-fix for #87

## Changes
- fix: resolve issue #87 — mark sleepWakeObserver as nonisolated(unsafe) to avoid data race in deinit

## Issue Reference
Closes #87

---
🤖 *此 PR 由 AI Fix Agent 自动创建*