### PR TITLE
fix: resolve #95 — 🟡 [AI-QA] PersistenceController double-loads persistent stores on corruption recovery

### DIFF
--- a/MacTimer/Persistence/PersistenceController.swift
+++ b/MacTimer/Persistence/PersistenceController.swift
@@ -50,6 +50,11 @@ struct PersistenceController {
                     PersistenceController.removeStoreFiles(at: storeURL)
                 }
 
+                // Remove any existing stores from the coordinator before retrying
+                for store in theContainer.persistentStoreCoordinator.persistentStores {
+                    try? theContainer.persistentStoreCoordinator.remove(store)
+                }
+
                 let retrySemaphore = DispatchSemaphore(value: 0)
                 theContainer.loadPersistentStores { _, retryError in
                     if let retryError = retryError {


### PR DESCRIPTION
## Summary
Auto-fix for #95

## Changes
- fix: resolve issue #95 — remove existing stores from coordinator before retry on corruption recovery

## Issue Reference
Closes #95

---
🤖 *此 PR 由 AI Fix Agent 自动创建*