### PR TITLE
fix: resolve #97 — 🟠 [AI-QA] Shell command validation bypass via allowed dangerous commands

### DIFF
--- a/MacTimer/Services/TaskExecutor.swift
+++ b/MacTimer/Services/TaskExecutor.swift
@@ -44,7 +44,12 @@ final class TaskExecutor {
         "pbcopy", "pbpaste",
         "defaults", "sw_vers", "system_profiler", "sysctl",
         "git", "svn",
-        "make", "xcodebuild", "xcrun",
+        "make", "xcodebuild",
+        // NOTE: xcrun is excluded because it can invoke arbitrary toolchain
+        // binaries (e.g. `xcrun swift`, `xcrun python3`), bypassing the allowlist.
+        // General-purpose scripting interpreters (python3, python, ruby, perl,
+        // node, swift) are intentionally excluded — they can execute arbitrary
+        // code that bypasses both the allowlist and metacharacter checks.
         "brew",
         "man", "apropos", "info",
         "less", "more",


### PR DESCRIPTION
## Summary
Auto-fix for #97

## Changes
- fix: resolve issue #97 — remove xcrun from allowlist and document scripting interpreter exclusion

## Issue Reference
Closes #97

---
🤖 *此 PR 由 AI Fix Agent 自动创建*